### PR TITLE
Add ‘bignumber.js’ package to avoid build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/request": "^2.0.0",
     "@types/tmp": "^0.0.33",
     "@types/url-join": "^0.8.2",
+    "bignumber.js": "^4.1.0",
     "bluebird": "^3.5.0",
     "commander": "^2.9.0",
     "cors": "^2.8.1",


### PR DESCRIPTION
I just found a reason which caused from importing `bignumber.js`. It was just a problem of package missing in `package.json`.
```
Error at index.ts:8:8: Module '"/Users/kwangin/workspace/machinomy/node_modules/@types/bignumber.js/index"' has no default export.
Error at lib/ChannelContractDefault.ts:3:8: Module '"/Users/kwangin/workspace/machinomy/node_modules/@types/bignumber.js/index"' has no default export.
Error at lib/ChannelContractToken.ts:3:8: Module '"/Users/kwangin/workspace/machinomy/node_modules/@types/bignumber.js/index"' has no default export.
Error at lib/channel.ts:4:8: Module '"/Users/kwangin/workspace/machinomy/node_modules/@types/bignumber.js/index"' has no default export.
```
Please look on. Thanks.