### PR TITLE
Add minimum settlemend period validation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -52,6 +52,7 @@ export interface NextPaymentResult {
 export interface MachinomyOptions {
   databaseUrl: string
   minimumChannelAmount?: number | BigNumber.BigNumber
+  minimumSettlementPeriod?: number
   settlementPeriod?: number
 }
 
@@ -93,9 +94,8 @@ export default class Machinomy {
   private account: string
   /** Web3 instance that manages {@link Machinomy.account}'s private key */
   private web3: Web3
+
   private engine: Engine
-  private minimumChannelAmount?: BigNumber.BigNumber
-  private settlementPeriod?: number
 
   private channelContract: ChannelContract
 
@@ -144,11 +144,6 @@ export default class Machinomy {
     this.account = account
     this.web3 = web3
     this.engine = this.serviceContainer.resolve('Engine')
-    this.settlementPeriod = options.settlementPeriod
-
-    if (options.minimumChannelAmount) {
-      this.minimumChannelAmount = new BigNumber.BigNumber(options.minimumChannelAmount)
-    }
   }
 
   /**

--- a/integration_test/buy_flow.test.ts
+++ b/integration_test/buy_flow.test.ts
@@ -34,7 +34,8 @@ describe('Buy flow', () => {
     hubPort = randomPort()
 
     hubInstance = new Machinomy(receiver, web3, {
-      databaseUrl: `nedb:///tmp/machinomy-hub-${Date.now()}`
+      databaseUrl: `nedb:///tmp/machinomy-hub-${Date.now()}`,
+      minimumSettlementPeriod: 0
     })
 
     clientInstance = new Machinomy(sender, web3, {

--- a/integration_test/payment_validation_flow.test.ts
+++ b/integration_test/payment_validation_flow.test.ts
@@ -1,0 +1,90 @@
+import Web3 = require('web3')
+import * as BigNumber from 'bignumber.js'
+import * as express from 'express'
+import * as bodyParser from 'body-parser'
+import Machinomy, { BuyResult } from '../index'
+import expectsRejection from '../test/util/expects_rejection'
+const expect = require('expect')
+
+const web3 = new Web3(new Web3.providers.HttpProvider(process.env.MACHINOMY_GETH_ADDR as string))
+const sender = process.env.SENDER_ADDRESS as string
+const receiver = process.env.RECEIVER_ADDRESS as string
+
+describe('Payment validation flow', () => {
+  const price = new BigNumber.BigNumber(web3.toWei(0.1, 'ether'))
+
+  let hubPort: number
+
+  let hubInstance: Machinomy
+
+  let clientInstance: Machinomy
+
+  let hubServer: any
+
+  let serverListener: any
+
+  describe('minimum settlement period', () => {
+    before((done) => {
+      hubPort = randomPort()
+
+      hubInstance = new Machinomy(receiver, web3, {
+        databaseUrl: `nedb:///tmp/machinomy-hub-${Date.now()}`,
+        minimumSettlementPeriod: 10
+      })
+
+      clientInstance = new Machinomy(sender, web3, {
+        settlementPeriod: 0,
+        databaseUrl: `nedb:///tmp/machinomy-client-${Date.now()}`
+      })
+
+      hubServer = express()
+      hubServer.use(bodyParser.json())
+      hubServer.use(bodyParser.urlencoded({ extended: false }))
+      hubServer.post('/machinomy', async (req: express.Request, res: express.Response) => {
+        try {
+          const body = await hubInstance.acceptPayment(req.body)
+          res.status(200).send(body)
+        } catch (e) {
+          res.sendStatus(400)
+        }
+      })
+
+      serverListener = hubServer.listen(hubPort, done)
+    })
+
+    after(async () => {
+      await hubInstance.shutdown()
+      await clientInstance.shutdown()
+      serverListener.close()
+    })
+
+    it('should reject payments with a settlement period lower than the minimum', async () => {
+      return expectsRejection(clientInstance.buy({
+        receiver,
+        price,
+        gateway: `http://localhost:${hubPort}/machinomy`,
+        meta: ''
+      }))
+    })
+
+    it('should accept payments with a settlement period higher than the minimum', () => {
+      clientInstance = new Machinomy(sender, web3, {
+        settlementPeriod: 11,
+        databaseUrl: `nedb:///tmp/machinomy-client-${Date.now()}`
+      })
+
+      return clientInstance.buy({
+        receiver,
+        price,
+        gateway: `http://localhost:${hubPort}/machinomy`,
+        meta: ''
+      }).then((res: BuyResult) => {
+        expect(res.token.length).toBeGreaterThan(0)
+      })
+    })
+  })
+})
+
+function randomPort (): number {
+  return 3000 + Math.floor(10000 * Math.random())
+}

--- a/lib/channel_contract.ts
+++ b/lib/channel_contract.ts
@@ -66,6 +66,19 @@ export default class ChannelContract {
     return 2
   }
 
+  async getSettlementPeriod (channelId: string): Promise<BigNumber.BigNumber> {
+    LOG(`Fetching settlement period for channel ${channelId}`)
+    const deployed = await this.contract()
+    const exists = await deployed.isPresent(channelId)
+
+    if (!exists) {
+      throw new Error(`Cannot fetch settlement period for non-existent channel ${channelId}.`)
+    }
+
+    const chan = await deployed.channels(channelId)
+    return chan[3]
+  }
+
   async startSettle (account: string, channelId: string): Promise<TransactionResult> {
     LOG(`Starting settle for account ${account} and channel id ${channelId}.`)
     const deployed = await this.contract()

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -107,8 +107,8 @@ export default function defaultRegistry (): Registry {
   }, ['Engine', 'namespace'])
 
   serviceRegistry.bind('PaymentManager',
-    (chainManager: ChainManager, channelContract: ChannelContract) => new PaymentManager(chainManager, channelContract),
-    ['ChainManager', 'ChannelContract'])
+    (chainManager: ChainManager, channelContract: ChannelContract, options: MachinomyOptions) => new PaymentManager(chainManager, channelContract, options),
+    ['ChainManager', 'ChannelContract', 'MachinomyOptions'])
 
   return serviceRegistry
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "migrate": "db-migrate up",
-    "integration_test": "yarn build && NODE_ENV=test mocha \"integration_test/**/*.test.js\"",
+    "integration_test": "yarn build-test && NODE_ENV=test mocha integration_test/**/*.test.js",
     "test_nedb": "NODE_ENV=test ENGINE_NAME=nedb mocha",
     "test_mongo": "NODE_ENV=test ENGINE_NAME=mongo mocha",
     "test_postgres": "NODE_ENV=test ENGINE_NAME=postgresql mocha",

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -58,7 +58,7 @@ TMP_DIR="/tmp/machinomy-itests-$NOW"
 mkdir ${TMP_DIR}
 cd ${TMP_DIR}
 echo "Downloading and extracting @machinomy/contracts..."
-wget https://github.com/machinomy/machinomy-contracts/archive/v4.0.1.tar.gz > /dev/null 2>&1
+curl -sL https://github.com/machinomy/machinomy-contracts/archive/v4.0.1.tar.gz --output v4.0.1.tar.gz
 tar -xzf v4.0.1.tar.gz
 cd machinomy-contracts-4.0.1
 echo "Installing contract dependencies..."

--- a/test/payment_manager.test.ts
+++ b/test/payment_manager.test.ts
@@ -12,12 +12,15 @@ describe('PaymentManager', () => {
 
   let channelContract: any
 
+  let options: any
+
   let manager: PaymentManager
 
   beforeEach(() => {
     chainManager = {}
     channelContract = {}
-    manager = new PaymentManager(chainManager, channelContract)
+    options = {}
+    manager = new PaymentManager(chainManager, channelContract, options)
   })
 
   describe('#buildPaymentForChannel', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,6 +63,6 @@
     "lib/*.ts",
     "types/*/index.d.ts",
     "test/*.ts",
-    "integration_test/*.ts"
+    "integration_test/**/*.ts"
   ]
 }


### PR DESCRIPTION
For context, senders can currently set the settlement period to zero and settle a channel before the payment hub has a chance to claim. This PR adds the ability to validate the channel's settlement period prior to accepting payment.