### PR TITLE
Adding pg-native breaks a lot of automated builds. The library doesn't appear to be maintained anymore and seems incompatible with later versions of node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "fetch-ponyfill": "^5.0.1",
     "homedir": "https://github.com/ukstv/node-homedir",
     "nedb": "^1.8.0",
-    "pg-native": "^2.2.0",
     "prompt": "^1.0.0",
     "request": "^2.76.0",
     "request-promise-native": "^1.0.5",


### PR DESCRIPTION
Adding pg-native breaks a lot of automated builds. The library doesn't appear to be maintained anymore and seems incompatible with later versions of node.

Revert "Fix compatibility with mc_wallet issue 'Module not found: Error: Can't resolve 'pg-native' in ...'."

This reverts commit d718677b19d335f29ce6efc2c77090a0b0bbea95.