### PR TITLE
Remove increment check

### DIFF
--- a/lib/payment_manager.ts
+++ b/lib/payment_manager.ts
@@ -39,7 +39,6 @@ export default class PaymentManager {
 
   async isValid (payment: Payment, paymentChannel: PaymentChannel): Promise<boolean> {
     const settlementPeriod = await this.channelContract.getSettlementPeriod(payment.channelId)
-    const validIncrement = (paymentChannel.spent.plus(payment.price)).lessThanOrEqualTo(paymentChannel.value)
     const validChannelValue = paymentChannel.value.equals(payment.channelValue)
     const validChannelId = paymentChannel.channelId === payment.channelId
     const validPaymentValue = paymentChannel.value.lessThanOrEqualTo(payment.channelValue)
@@ -49,8 +48,7 @@ export default class PaymentManager {
     const isAboveMinSettlementPeriod = new BigNumber.BigNumber(this.options.minimumSettlementPeriod || DEFAULT_SETTLEMENT_PERIOD)
       .lessThanOrEqualTo(settlementPeriod)
 
-    return validIncrement &&
-      validChannelValue &&
+    return validChannelValue &&
       validPaymentValue &&
       validSender &&
       validChannelId &&


### PR DESCRIPTION
@ukstv - this removes the increment check in `isValid`. `nextPayment` sums the payment value (which becomes the `spent` value in `PaymentChannel.fromPayment`) prior to sending it to the backend. This means that the increment is invalid if you attempt to send more than half of the remaining channel value. I don't think this check is necessary, so I removed it.