### PR TITLE
Don't spend channels until hub has responded successfully

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -148,11 +148,13 @@ export default class Machinomy {
 
     const payment = await this.nextPayment(options)
     const res: AcceptPaymentResponse = await this.client.doPayment(payment, options.gateway)
+    await this.channelManager.spendChannel(payment)
     return { token: res.token, channelId: payment.channelId }
   }
 
   async payment (options: BuyOptions): Promise<NextPaymentResult> {
     const payment = await this.nextPayment(options)
+    await this.channelManager.spendChannel(payment)
     return { payment: PaymentSerde.instance.serialize(payment) }
   }
 

--- a/lib/channel_manager.ts
+++ b/lib/channel_manager.ts
@@ -30,6 +30,8 @@ export interface ChannelManager extends EventEmitter {
 
   nextPayment (channelId: string | ChannelId, amount: BigNumber.BigNumber, meta: string): Promise<Payment>
 
+  spendChannel (payment: Payment): Promise<Payment>
+
   acceptPayment (payment: Payment): Promise<string>
 
   requireOpenChannel (sender: string, receiver: string, amount: BigNumber.BigNumber, minDepositAmount?: BigNumber.BigNumber): Promise<PaymentChannel>
@@ -114,11 +116,14 @@ export class ChannelManagerImpl extends EventEmitter implements ChannelManager {
         throw new Error(`Total spend ${toSpend.toString()} is larger than channel value ${channel.value.toString()}`)
       }
 
-      const payment = await this.paymentManager.buildPaymentForChannel(channel, amount, toSpend, meta)
-      const chan = PaymentChannel.fromPayment(payment)
-      await this.channelsDao.saveOrUpdate(chan)
-      return payment
+      return this.paymentManager.buildPaymentForChannel(channel, amount, toSpend, meta)
     })
+  }
+
+  async spendChannel (payment: Payment): Promise<Payment> {
+    const chan = PaymentChannel.fromPayment(payment)
+    await this.channelsDao.saveOrUpdate(chan)
+    return payment
   }
 
   acceptPayment (payment: Payment): Promise<string> {

--- a/test/channel_manager.test.ts
+++ b/test/channel_manager.test.ts
@@ -352,15 +352,47 @@ describe('ChannelManagerImpl', () => {
         })
       })
 
-      channelsDao.saveOrUpdate = sinon.stub().resolves()
-
       deployed.channels = sinon.stub().resolves(['0', '0',
         new BigNumber.BigNumber(10), new BigNumber.BigNumber(0), new BigNumber.BigNumber(0)])
 
       return channelManager.nextPayment(id, new BigNumber.BigNumber(8), '').then((payment: Payment) => {
-        expect((channelsDao.saveOrUpdate as sinon.SinonStub).called).toBe(true)
         expect(payment.value.eq(new BigNumber.BigNumber(10))).toBe(true)
         expect(payment.price.eq(new BigNumber.BigNumber(8))).toBe(true)
+      })
+    })
+  })
+
+  describe('spendChannel', () => {
+    it('should save the channel in the database', () => {
+      const payment = new Payment({
+        channelId: '0xdead',
+        sender: 'send',
+        receiver: 'recv',
+        price: new BigNumber.BigNumber(10),
+        value: new BigNumber.BigNumber(10),
+        channelValue: new BigNumber.BigNumber(100),
+        signature: Signature.fromParts({
+          v: 27,
+          r: '0x01',
+          s: '0x02'
+        }),
+        meta: '',
+        contractAddress: undefined,
+        token: undefined
+      })
+
+      channelsDao.saveOrUpdate = sinon.stub().resolves()
+
+      return channelManager.spendChannel(payment).then(() => {
+        expect((channelsDao.saveOrUpdate as sinon.SinonStub).calledWith({
+          sender: 'send',
+          receiver: 'recv',
+          channelId: '0xdead',
+          value: new BigNumber.BigNumber(10),
+          spent: new BigNumber.BigNumber(10),
+          state: undefined,
+          contractAddress: undefined
+        }))
       })
     })
   })


### PR DESCRIPTION
Can lead to a state where a client thinks money is spend when the hub does not.