### PR TITLE
chore: require machinomy-contracts v4.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@machinomy/contracts": "^4.0.5",
+    "@machinomy/contracts": "^4.0.9",
     "@machinomy/types-truffle-contract": "^0.0.3",
     "@machinomy/types-web3": "^0.0.4",
     "@types/bignumber.js": "^4.0.2",


### PR DESCRIPTION
On my machine, it had installed machinomy-contracts v4.0.6, which only has a Rinkeby contract for Unidirectional, and no Main or Ropsten. This changed fixed that problem for me.